### PR TITLE
https://github.com/OpenPaaS-Suite/esn/issues/24: Added missing dev dependency - dotenv-webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "command-line-args": "^5.1.1",
     "copy-dir": "^1.3.0",
     "css-loader": "^3.6.0",
+    "dotenv-webpack": "^2.0.0",
     "esn-frontend-login": "github:openpaas-suite/esn-frontend-login#main",
     "exports-loader": "^1.0.0",
     "expose-loader": "^1.0.0",


### PR DESCRIPTION
The PR https://github.com/OpenPaaS-Suite/esn-frontend-mailto/pull/11 was missing the `dotenv-webpack` dev dependency in `package.json`.