### PR TITLE
esn-frontend-mailto#34: Corrected the behaviour of the "Reopen composer" button when an email fails to be sent

### DIFF
--- a/src/app/components/mailto-page/mailto-page.component.spec.js
+++ b/src/app/components/mailto-page/mailto-page.component.spec.js
@@ -139,14 +139,19 @@ describe('The mailtoPage component', function() {
     });
 
     it('should reopen the composer when clicking on the \'Reopen composer\' button after the mail failed to be sent', function() {
-      mailtoMailStatusMock.getStatus = () => MAILTO_MAIL_STATUSES.FAILED;
+      const reopenComposer = sinon.stub();
+      mailtoMailStatusMock.getStatus = () => MAILTO_MAIL_STATUSES.SENDING;
 
       const element = initComponent();
+
+      $rootScope.$broadcast(MAILTO_MAIL_STATUS_EVENTS.UPDATED, MAILTO_MAIL_STATUSES.FAILED, { reopenComposer });
+      $timeout.flush();
+
       const reopenComposerButton = element.find(`${mailFailedContainerSelector} button.btn.btn-primary`);
 
       reopenComposerButton.click();
 
-      expect(mailtoMailComposerMock.openComposer).to.have.been.called;
+      expect(reopenComposer).to.have.been.called;
     });
 
     it('should close the window when clicking on the \'Close window\' button after the mail failed to be sent', function() {

--- a/src/app/components/mailto-page/mailto-page.component.spec.js
+++ b/src/app/components/mailto-page/mailto-page.component.spec.js
@@ -42,13 +42,19 @@ describe('The mailtoPage component', function() {
     return element;
   }
 
+  const mailSendingContainerSelector = 'div[ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.SENDING || $ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.TRANSITION"]';
+  const mailSentContainerSelector = 'div[ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.SENT"]';
+  const mailFailedContainerSelector = 'div[ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.FAILED"]';
+  const draftContainerSelector = 'div[ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.DISCARDING || $ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.DISCARDED"]';
+
   describe('When mail is being sent', function() {
+
     it('should show openpaas logo spinner when mail is being sent', function() {
       mailtoMailStatusMock.getStatus = () => MAILTO_MAIL_STATUSES.SENDING;
 
       const element = initComponent();
 
-      expect(element.find('.sending div').attr('openpaas-logo-spinner')).to.exist;
+      expect(element.find(`${mailSendingContainerSelector} div`).attr('openpaas-logo-spinner')).to.exist;
     });
   
     it('should still show openpaas logo spinner when the animation transition is happening', function() {
@@ -56,7 +62,7 @@ describe('The mailtoPage component', function() {
 
       const element = initComponent();
 
-      expect(element.find('.sending div').attr('openpaas-logo-spinner')).to.exist;
+      expect(element.find(`${mailSendingContainerSelector} div`).attr('openpaas-logo-spinner')).to.exist;
     });
 
     it('should react to mail status updated event when mail has been sent and change the status and content accordingly', function() {
@@ -66,12 +72,12 @@ describe('The mailtoPage component', function() {
 
       $rootScope.$broadcast(MAILTO_MAIL_STATUS_EVENTS.UPDATED, MAILTO_MAIL_STATUSES.SENT);
 
-      expect(element.find('.sending div').attr('openpaas-logo-spinner')).to.exist;
+      expect(element.find(`${mailSendingContainerSelector} div`).attr('openpaas-logo-spinner')).to.exist;
 
       $timeout.flush();
 
-      expect(element.find('.sending div')[0]).to.not.exist;
-      expect(element.find('.sent .icon-container svg title').text()).to.contain('Mail sent');
+      expect(element.find(`${mailSendingContainerSelector} div`)[0]).to.not.exist;
+      expect(element.find(`${mailSentContainerSelector} .icon-container svg title`).text()).to.contain('Mail sent');
     });
 
     it('should react to mail status updated event when mail failed to be sent and change the status and content accordingly', function() {
@@ -81,12 +87,12 @@ describe('The mailtoPage component', function() {
 
       $rootScope.$broadcast(MAILTO_MAIL_STATUS_EVENTS.UPDATED, MAILTO_MAIL_STATUSES.FAILED);
 
-      expect(element.find('.sending div').attr('openpaas-logo-spinner')).to.exist;
+      expect(element.find(`${mailSendingContainerSelector} div`).attr('openpaas-logo-spinner')).to.exist;
 
       $timeout.flush();
 
-      expect(element.find('.sending div')[0]).to.not.exist;
-      expect(element.find('.sent .icon-container svg title').text()).to.contain('Failed to send mail');
+      expect(element.find(`${mailSendingContainerSelector} div`)[0]).to.not.exist;
+      expect(element.find(`${mailFailedContainerSelector} .icon-container svg title`).text()).to.contain('Failed to send mail');
     });
   });
 
@@ -96,14 +102,14 @@ describe('The mailtoPage component', function() {
 
       const element = initComponent();
 
-      expect(element.find('.sent .icon-container svg title').text()).to.contain('Mail sent');
+      expect(element.find(`${mailSentContainerSelector} .icon-container svg title`).text()).to.contain('Mail sent');
     });
 
     it('should reopen the composer when clicking on the \'Send another\' button after the mail failed to be sent', function() {
       mailtoMailStatusMock.getStatus = () => MAILTO_MAIL_STATUSES.SENT;
 
       const element = initComponent();
-      const reopenComposerButton = element.find('.sent button.btn.btn-primary');
+      const reopenComposerButton = element.find(`${mailSentContainerSelector} button.btn.btn-primary`);
 
       reopenComposerButton.click();
 
@@ -115,7 +121,7 @@ describe('The mailtoPage component', function() {
       mailtoMailStatusMock.getStatus = () => MAILTO_MAIL_STATUSES.SENT;
 
       const element = initComponent();
-      const closeWindowButton = element.find('.sent button.btn.btn-link');
+      const closeWindowButton = element.find(`${mailSentContainerSelector} button.btn.btn-link`);
 
       closeWindowButton.click();
 
@@ -129,14 +135,14 @@ describe('The mailtoPage component', function() {
 
       const element = initComponent();
 
-      expect(element.find('.sent .icon-container svg title').text()).to.contain('Failed to send mail');
+      expect(element.find(`${mailFailedContainerSelector} .icon-container svg title`).text()).to.contain('Failed to send mail');
     });
 
     it('should reopen the composer when clicking on the \'Reopen composer\' button after the mail failed to be sent', function() {
       mailtoMailStatusMock.getStatus = () => MAILTO_MAIL_STATUSES.FAILED;
 
       const element = initComponent();
-      const reopenComposerButton = element.find('.sent button.btn.btn-primary');
+      const reopenComposerButton = element.find(`${mailFailedContainerSelector} button.btn.btn-primary`);
 
       reopenComposerButton.click();
 
@@ -148,7 +154,7 @@ describe('The mailtoPage component', function() {
       mailtoMailStatusMock.getStatus = () => MAILTO_MAIL_STATUSES.FAILED;
 
       const element = initComponent();
-      const closeWindowButton = element.find('.sent button.btn.btn-link');
+      const closeWindowButton = element.find(`${mailFailedContainerSelector} button.btn.btn-link`);
 
       closeWindowButton.click();
 
@@ -162,7 +168,7 @@ describe('The mailtoPage component', function() {
 
       const element = initComponent();
 
-      expect(element.find('.draft .icon-container svg title').text()).to.contain('Delete draft');
+      expect(element.find(`${draftContainerSelector} .icon-container svg title`).text()).to.contain('Delete draft');
     });
 
     it('should allow reopening the draft when clicking on the \'Reopen draft\' button', function() {
@@ -174,11 +180,11 @@ describe('The mailtoPage component', function() {
       $rootScope.$broadcast(MAILTO_MAIL_STATUS_EVENTS.UPDATED, MAILTO_MAIL_STATUSES.DISCARDING, { reopenDraft });
       $rootScope.$digest();
 
-      const reopenDraftButton = element.find('.draft button.btn.btn-primary');
+      const reopenDraftButton = element.find(`${draftContainerSelector} button.btn.btn-primary`);
 
       reopenDraftButton.click();
 
-      expect(element.find('.draft button.btn.btn-primary').attr('title')).to.equal('');
+      expect(element.find(`${draftContainerSelector} button.btn.btn-primary`).attr('title')).to.equal('');
       expect(reopenDraft).to.have.been.called;
     });
 
@@ -187,7 +193,7 @@ describe('The mailtoPage component', function() {
       mailtoMailStatusMock.getStatus = () => MAILTO_MAIL_STATUSES.DISCARDING;
 
       const element = initComponent();
-      const closeWindowButton = element.find('.draft button.btn.btn-link');
+      const closeWindowButton = element.find(`${draftContainerSelector} button.btn.btn-link`);
 
       closeWindowButton.click();
 
@@ -201,7 +207,7 @@ describe('The mailtoPage component', function() {
 
       const element = initComponent();
 
-      expect(element.find('.draft .icon-container svg title').text()).to.contain('Delete draft');
+      expect(element.find(`${draftContainerSelector} .icon-container svg title`).text()).to.contain('Delete draft');
     });
 
     it('should disable the \'Reopen draft\' button and update its title', function() {
@@ -212,7 +218,7 @@ describe('The mailtoPage component', function() {
       $rootScope.$broadcast(MAILTO_MAIL_STATUS_EVENTS.UPDATED, MAILTO_MAIL_STATUSES.DISCARDED);
       $rootScope.$digest();
 
-      const reopenDraftButton = element.find('.draft button.btn.btn-primary');
+      const reopenDraftButton = element.find(`${draftContainerSelector} button.btn.btn-primary`);
 
       expect(reopenDraftButton.attr('title')).to.equal('The draft has already been discarded');
       expect(reopenDraftButton.attr('disabled')).to.exist;
@@ -223,7 +229,7 @@ describe('The mailtoPage component', function() {
       mailtoMailStatusMock.getStatus = () => MAILTO_MAIL_STATUSES.DISCARDED;
 
       const element = initComponent();
-      const closeWindowButton = element.find('.draft button.btn.btn-link');
+      const closeWindowButton = element.find(`${draftContainerSelector} button.btn.btn-link`);
 
       closeWindowButton.click();
 

--- a/src/app/components/mailto-page/mailto-page.controller.js
+++ b/src/app/components/mailto-page/mailto-page.controller.js
@@ -26,6 +26,10 @@ angular
       if (newStatus === self.MAILTO_MAIL_STATUSES.SENT || newStatus === self.MAILTO_MAIL_STATUSES.FAILED) {
         self.status = self.MAILTO_MAIL_STATUSES.TRANSITION;
 
+        if (newStatus === self.MAILTO_MAIL_STATUSES.FAILED && options && typeof options.reopenComposer === 'function') {
+          self.reopenComposer = options.reopenComposer;
+        }
+
         // This has to be 500ms to be in sync with the animation time defined in the LESS file.
         $timeout(() => {
           self.status = newStatus;

--- a/src/app/components/mailto-page/mailto-page.less
+++ b/src/app/components/mailto-page/mailto-page.less
@@ -56,7 +56,7 @@ mailto-page {
     .flex-vertical-centered;
     .flex-column;
 
-    &.sent .icon-container {
+    .icon-container {
       width: 11em;
       height: 11em;
       font-size: 1.5em;

--- a/src/app/components/mailto-page/mailto-page.pug
+++ b/src/app/components/mailto-page/mailto-page.pug
@@ -20,7 +20,7 @@ div.container(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.FAILED")
     include ../../../../assets/undraw_MailFailed.svg
   p.status-message {{ 'Sorry, we could not send your message.' | translate }}
   div.actions
-    button.btn.btn-primary.waves-effect(ng-click="$ctrl.sendAnother()") {{ 'Reopen composer' | translate }}
+    button.btn.btn-primary.waves-effect(ng-click="$ctrl.reopenComposer()") {{ 'Reopen composer' | translate }}
     button.btn.btn-link.waves-effect(ng-click="$ctrl.closeWindow()") {{ 'Close window' | translate }}
 
 div.container(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.DISCARDING || $ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.DISCARDED")

--- a/src/app/components/mailto-page/mailto-page.pug
+++ b/src/app/components/mailto-page/mailto-page.pug
@@ -1,4 +1,4 @@
-div.container.sending(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.SENDING || $ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.TRANSITION")
+div.container(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.SENDING || $ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.TRANSITION")
   div.text-center(openpaas-logo-spinner, spinner-start-active='1', spinner-size='1.5', ng-class="{ zoomOut: $ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.TRANSITION }")
   p.status-message
     span {{ 'Your message is being sent' | translate }}
@@ -7,7 +7,7 @@ div.container.sending(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.SENDING
       span .
       span .
 
-div.container.sent(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.SENT")
+div.container(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.SENT")
   .icon-container.zoomIn
     include ../../../../assets/undraw_MailSent.svg
   p.status-message {{ 'Your message has been sent successfully.' | translate }}
@@ -15,7 +15,7 @@ div.container.sent(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.SENT")
     button.btn.btn-primary.waves-effect(ng-click="$ctrl.sendAnother()") {{ 'Send another' | translate }}
     button.btn.btn-link.waves-effect(ng-click="$ctrl.closeWindow()") {{ 'Close window' | translate }}
 
-div.container.sent(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.FAILED")
+div.container(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.FAILED")
   .icon-container.zoomIn
     include ../../../../assets/undraw_MailFailed.svg
   p.status-message {{ 'Sorry, we could not send your message.' | translate }}
@@ -23,7 +23,7 @@ div.container.sent(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.FAILED")
     button.btn.btn-primary.waves-effect(ng-click="$ctrl.sendAnother()") {{ 'Reopen composer' | translate }}
     button.btn.btn-link.waves-effect(ng-click="$ctrl.closeWindow()") {{ 'Close window' | translate }}
 
-div.container.draft(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.DISCARDING || $ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.DISCARDED")
+div.container(ng-if="$ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.DISCARDING || $ctrl.status === $ctrl.MAILTO_MAIL_STATUSES.DISCARDED")
   .icon-container.zoomIn
     include ../../../../assets/undraw_DeleteDraft.svg
   p.status-message {{ 'Your draft has been discarded. The window will be closed in a few seconds...' | translate }}

--- a/src/app/services/mail-composer/mail-composer.service.js
+++ b/src/app/services/mail-composer/mail-composer.service.js
@@ -31,8 +31,8 @@ angular
         onSend: function () {
           mailtoMailStatus.updateStatus(MAILTO_MAIL_STATUSES.SENT);
         },
-        onFail: function () {
-          mailtoMailStatus.updateStatus(MAILTO_MAIL_STATUSES.FAILED);
+        onFail: function (reopenComposer) {
+          mailtoMailStatus.updateStatus(MAILTO_MAIL_STATUSES.FAILED, { reopenComposer });
         },
         onDiscarding: function (reopenDraft) {
           mailtoMailStatus.updateStatus(MAILTO_MAIL_STATUSES.DISCARDING, { reopenDraft });

--- a/src/app/services/mail-composer/mail-composer.service.spec.js
+++ b/src/app/services/mail-composer/mail-composer.service.spec.js
@@ -55,8 +55,11 @@ describe('The mailtoMailComposer service', function() {
     };
 
     const testOnFail = (onFail) => {
-      onFail();
-      expect(mailtoMailStatusMock.updateStatus).to.have.been.calledWith(MAILTO_MAIL_STATUSES.FAILED);
+      const reopenComposer = () => {};
+
+      onFail(reopenComposer);
+
+      expect(mailtoMailStatusMock.updateStatus).to.have.been.calledWith(MAILTO_MAIL_STATUSES.FAILED, { reopenComposer });
     };
 
     const testOnDiscarding = (onDiscarding) => {


### PR DESCRIPTION
Partially resolves #34. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-inbox/pull/103.

- Demo:

![Mailto-Failed-Reopen-Composer](https://user-images.githubusercontent.com/24670327/91795169-240ebc00-ec47-11ea-871e-803019132a73.gif)

- All of the tests are passing:

![image](https://user-images.githubusercontent.com/24670327/91795292-794acd80-ec47-11ea-8c99-1fa54a681e4f.png)
